### PR TITLE
replaced mock with fake/stub for SendMoneyServiceTest

### DIFF
--- a/src/test/java/io/reflectoring/buckpal/account/application/service/FakeAccountRepository.java
+++ b/src/test/java/io/reflectoring/buckpal/account/application/service/FakeAccountRepository.java
@@ -1,0 +1,28 @@
+package io.reflectoring.buckpal.account.application.service;
+
+import io.reflectoring.buckpal.account.application.port.out.LoadAccountPort;
+import io.reflectoring.buckpal.account.application.port.out.UpdateAccountStatePort;
+import io.reflectoring.buckpal.account.domain.Account;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+public class FakeAccountRepository implements LoadAccountPort, UpdateAccountStatePort {
+
+    Map<Account.AccountId, Account> accounts = new HashMap();
+
+    public void addAccount(Account account) {
+        accounts.put(account.getId().get(), account);
+    }
+
+    @Override
+    public Account loadAccount(Account.AccountId accountId, LocalDateTime baselineDate) {
+        return accounts.get(accountId);
+    }
+
+    @Override
+    public void updateActivities(Account account) {
+        // no op
+    }
+}


### PR DESCRIPTION
Hi,

I read your book *Get Your Hands Dirty on Clean Architecture* and I liked it very much. I almost agree with everything on it.

But one thing is bothering me: it's the usage of mocks in tests. From experience, I know, tests with mocks are brittle. Further the test code is deluged with mock-statements and harder to comprehend.

The main purpose of hexagonal or clean architecture is **loose coupling**. I wonder why we completely through the good intention over board for our test code?!? With mocks, we completely expose the internals of our implementation classes and therefore *we loose the ability to refactor the inner details of our service classes*. Whereby **refactoring** is a major reason, why we write tests after all.

This PR offers a small taste, how tests could look like with fakes/stubs instead of mocks. Regarding the tests, I tried to assert one behaviour per test in order to assure tests break because of a single reason, this narrows down the potential problem area.

Mocks could be useful in rare cases though. The classic example is: testing a cache. With state verification only, you can only check the returned value, but one would not know if the value came from the database or from the cache. With mocks, one can verify that the first call returned from the database and the second call returned from the cache.

