### PR TITLE
docs: update documentation to reference JDK 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,5 +15,5 @@ It implements a domain-centric "Hexagonal" approach of a common web application 
 
 ## Prerequisites
 
-* JDK 11
+* JDK 17
 * this project uses Lombok, so enable annotation processing in your IDE


### PR DESCRIPTION
According build.gradle content and especially for using Java Text Blocks introduced as preview in JDK 13 and supported since JDK 15