### PR TITLE
Fix: remove public access modifier

### DIFF
--- a/src/main/java/io/reflectoring/buckpal/application/domain/service/SendMoneyService.java
+++ b/src/main/java/io/reflectoring/buckpal/application/domain/service/SendMoneyService.java
@@ -16,7 +16,7 @@ import java.time.LocalDateTime;
 @RequiredArgsConstructor
 @UseCase
 @Transactional
-public class SendMoneyService implements SendMoneyUseCase {
+class SendMoneyService implements SendMoneyUseCase {
 
 	private final LoadAccountPort loadAccountPort;
 	private final AccountLock accountLock;


### PR DESCRIPTION
Access modifier of port implementation classes is set to package-private (java default access modifier) to avoid dependencies on the other port implementation classes in your project.

However, in the case of the SendMoneyService class, `public` access modifier is being used in the project. So, I removed it.
